### PR TITLE
minor fix for hubconf

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -71,11 +71,11 @@ def PGAN(pretrained=False, *args, **kwargs):
     pretrained (bool): a recommended kwargs for all entrypoints
     args & kwargs are arguments for the function
     """
-    from models.progressive_gan import ProgressiveGAN as PGAN
-    if 'config' not in kwargs or kwargs['config'] is None:
+    from models.progressive_gan import PGAN
+    if config not in kwargs or kwargs['config'] is None::
         kwargs['config'] = {}
 
-    model = PGAN(useGPU=kwargs['useGPU'],
+    model = PGAN(useGPU=kwargs.get('useGPU', True),
                  storeAVG=True,
                  **kwargs['config'])
 
@@ -90,11 +90,11 @@ def DCGAN(pretrained=False, *args, **kwargs):
     pretrained (bool): a recommended kwargs for all entrypoints
     args & kwargs are arguments for the function
     """
-    from models.progressive_gan import ProgressiveGAN as DCGAN
-    if 'config' not in kwargs or kwargs['config'] is None:
+    from models.DCGAN import DCGAN
+    if config not in kwargs or kwargs['config'] is None:
         kwargs['config'] = {}
 
-    model = DCGAN(useGPU=kwargs['useGPU'],
+    model = DCGAN(useGPU=kwargs.get('useGPU', True),
                   storeAVG=True,
                   **kwargs['config'])
 


### PR DESCRIPTION
A few minor fix to get hubconf local test running. 

To test locally:
1. Clone and rename this repo to `~/.torch/hub/pytorch_GAN_zoo_REFACTOR_hubconf`
2. run with pytorch 1.0+
```
import torch.hub
torch.hub.load('fairinternal/pytorch_GAN_zoo:REFACTOR_hubconf', 'DCGAN',useGPU=True, pretrained=False)
#pretrained=True is waiting for pretrained weights to be available. 
```
