### PR TITLE
Undefined name: 'AttribDataset' on lines 137, 142, and 304

### DIFF
--- a/models/metrics/nn_score.py
+++ b/models/metrics/nn_score.py
@@ -12,6 +12,7 @@ import scipy
 import scipy.spatial
 import numpy
 
+from models.datasets.attrib_dataset import AttribDataset
 from ..datasets.hd5 import H5Dataset
 from ..loss_criterions.ac_criterion import ACGanCriterion
 from ..utils.utils import printProgressBar, loadmodule


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/facebookresearch/pytorch_GAN_zoo on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./models/trainer/DCGAN_trainer.py:19:16: F821 undefined name 'PPGANTrainer'
        return PPGANTrainer._defaultConfig
               ^
./models/metrics/nn_score.py:136:15: F821 undefined name 'AttribDataset'
    dataset = AttribDataset(pathDB, transform=transform,
              ^
./models/metrics/nn_score.py:141:25: F821 undefined name 'AttribDataset'
    validationDataset = AttribDataset(pathDB, transform=transform,
                        ^
./models/metrics/nn_score.py:303:19: F821 undefined name 'AttribDataset'
        dataset = AttribDataset(pathDB, transform=transform,
                  ^
4     F821 undefined name 'AttribDataset'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree