### PR TITLE
BUGFIX: minibatch_std_dev module

### DIFF
--- a/models/networks/mini_batch_stddev_module.py
+++ b/models/networks/mini_batch_stddev_module.py
@@ -22,8 +22,8 @@ def miniBatchStdDev(x, subGroupSize=4):
         subGroupSize = size[0]
     G = int(size[0] / subGroupSize)
     if subGroupSize > 1:
-        y = x.view(subGroupSize, -1, size[1], size[2], size[3])
-        y = torch.var(y, 0)
+        y = x.view(-1, subGroupSize, size[1], size[2], size[3])
+        y = torch.var(y, 1)
         y = torch.sqrt(y + 1e-8)
         y = y.view(G, -1)
         y = torch.mean(y, 1).view(G, 1)

--- a/models/trainer/progressive_gan_trainer.py
+++ b/models/trainer/progressive_gan_trainer.py
@@ -5,6 +5,7 @@ from .standard_configurations.pgan_config import _C
 from ..progressive_gan import ProgressiveGAN
 from .gan_trainer import GANTrainer
 from ..utils.utils import getMinOccurence
+import torch.nn.functional as F
 
 
 class ProgressiveGANTrainer(GANTrainer):


### PR DESCRIPTION
https://github.com/facebookresearch/pytorch_GAN_zoo/issues/69

The order of the group has been changed to make it easier to read and follow.
Now the code 
`a = torch.tensor([0, 0 , 0, 0, 1, 2, 3, 4, 100, 200, 300, 400], dtype=torch.float32)`
`a = a.view(-1, 1, 1, 1) `
`b = miniBatchStdDev(a, 4)`
`print(b[:, -1, 0, 0])`

Will output:
`tensor([1.0000e-04, 1.0000e-04, 1.0000e-04, 1.0000e-04, 1.2910e+00, 1.2910e+00,
        1.2910e+00, 1.2910e+00, 1.2910e+02, 1.2910e+02, 1.2910e+02, 1.2910e+02])`