### PR TITLE
Replace scipy.misc.imresize with PIL.Image.resize

### DIFF
--- a/models/utils/image_transform.py
+++ b/models/utils/image_transform.py
@@ -28,8 +28,8 @@ class NumpyResize(object):
 
             np array: resized image
         """
-
-        return scipy.misc.imresize(img, self.size, interp='bilinear')
+        
+        return np.array(img.resize(self.size, resample=Image.BILINEAR))
 
     def __repr__(self):
         return self.__class__.__name__ + '(p={})'.format(self.p)

--- a/visualization/np_visualizer.py
+++ b/visualization/np_visualizer.py
@@ -4,6 +4,7 @@ import scipy
 import scipy.misc
 import imageio
 import torch
+from PIL import Image
 
 
 def make_numpy_grid(arrays_list, gridMaxWidth=2048,
@@ -13,7 +14,7 @@ def make_numpy_grid(arrays_list, gridMaxWidth=2048,
     # NCWH format
     N, C, W, H = arrays_list.shape
 
-    arrays_list = (arrays_list + 1.0) * 255.0 / 2.0
+    arrays_list = ((arrays_list + 1.0) * 255.0 / 2.0).astype(np.uint8)
 
     if C == 1:
         arrays_list = np.reshape(arrays_list, (N, W, H))
@@ -37,6 +38,13 @@ def make_numpy_grid(arrays_list, gridMaxWidth=2048,
         outGrid = np.zeros((gridHeight, gridWidth, C), dtype='uint8')
     outGrid += 255
 
+    interp = {
+        'nearest': Image.NEAREST, 
+        'lanczos': Image.LANCZOS, 
+        'bilinear': Image.BILINEAR, 
+        'bicubic': Image.BICUBIC
+    }
+
     indexImage = 0
     for r in range(nRows):
         for c in range(nImgsPerRows):
@@ -47,8 +55,10 @@ def make_numpy_grid(arrays_list, gridMaxWidth=2048,
             xStart = c * imgSize
             yStart = r * imgHeight
 
-            tmpImage = scipy.misc.imresize(
-                arrays_list[indexImage], (imgSize, imgHeight), interp=interpolation)
+            img = np.array(arrays_list[indexImage])
+            img = Image.fromarray(np.transpose(img, (2,1,0)))
+
+            tmpImage = np.array(img.resize((imgSize, imgHeight), resample=interp[interpolation]))
 
             if C == 1:
                 outGrid[yStart:(yStart + imgHeight),

--- a/visualization/np_visualizer.py
+++ b/visualization/np_visualizer.py
@@ -56,7 +56,7 @@ def make_numpy_grid(arrays_list, gridMaxWidth=2048,
             yStart = r * imgHeight
 
             img = np.array(arrays_list[indexImage])
-            img = Image.fromarray(np.transpose(img, (2,1,0)))
+            img = Image.fromarray(np.transpose(img, (1,2,0)))
 
             tmpImage = np.array(img.resize((imgSize, imgHeight), resample=interp[interpolation]))
 


### PR DESCRIPTION
scipy.misc.imresize has been removed in SciPy 1.3.0.
Replaced with recommended substitute from:
https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html

An error occurred when running the CIFAR-10 example from the README:
`python train.py PGAN -c config_cifar10.json --restart -n cifar10`

