### PR TITLE
Handle overriding lists

### DIFF
--- a/models/utils/config.py
+++ b/models/utils/config.py
@@ -69,6 +69,12 @@ def updateParserWithConfig(parser, defaultConfig):
 
         if isinstance(key, bool):
             parser.add_argument('--' + name, type=str2bool, dest=name)
+        elif isinstance(key, list):
+            parser_type = int
+            if name == 'alphaJumpVals':
+                parser_type = float
+
+            parser.add_argument('--' + name, nargs='+', dest=name, type=parser_type)
         else:
             parser.add_argument('--' + name, type=type(key), dest=name)
 


### PR DESCRIPTION
List arguments gets correct argument type, allowing setting configuration overrides lists like `--maxIterAtScale`.

Example:
`python train.py PGAN -c "<configPath>" -n "<modelName>" -d "<outputDir>" --restart --save_iter 6000 --maxIterAtScale 12000 24000 24000 24000 24000 24000 24000 24000 48000`